### PR TITLE
GH-6: Dedicated CF option for source and sink [1.3.x]

### DIFF
--- a/spring-cloud-starter-stream-sink-rabbit/README.adoc
+++ b/spring-cloud-starter-stream-sink-rabbit/README.adoc
@@ -49,6 +49,7 @@ $$rabbit.converter-bean-name$$:: $$The bean name for a custom message converter;
 $$rabbit.exchange$$:: $$Exchange name - overridden by exchangeNameExpression, if supplied.$$ *($$String$$, default: `$$<empty string>$$`)*
 $$rabbit.exchange-expression$$:: $$A SpEL expression that evaluates to an exchange name.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$rabbit.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$[*]$$`)*
+$$rabbit.own-connection$$:: $$When true, use a separate connection based on the boot properties.$$ *($$Boolean$$, default: `$$false$$`)*
 $$rabbit.persistent-delivery-mode$$:: $$Default delivery mode when 'amqp_deliveryMode' header is not present,
  true for PERSISTENT.$$ *($$Boolean$$, default: `$$false$$`)*
 $$rabbit.routing-key$$:: $$Routing key - overridden by routingKeyExpression, if supplied.$$ *($$String$$, default: `$$<none>$$`)*

--- a/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkProperties.java
@@ -71,6 +71,11 @@ public class RabbitSinkProperties {
 	 */
 	private String converterBeanName;
 
+	/**
+	 * When true, use a separate connection based on the boot properties.
+	 */
+	private boolean ownConnection;
+
 	public String getExchange() {
 		return this.exchange;
 	}
@@ -130,6 +135,14 @@ public class RabbitSinkProperties {
 	@AssertTrue(message = "routingKey or routingKeyExpression is required")
 	public boolean isRoutingKeyProvided() {
 		return this.routingKey != null || this.routingKeyExpression != null;
+	}
+
+	public boolean isOwnConnection() {
+		return this.ownConnection;
+	}
+
+	public void setOwnConnection(boolean ownConnection) {
+		this.ownConnection = ownConnection;
 	}
 
 }

--- a/spring-cloud-starter-stream-source-rabbit/README.adoc
+++ b/spring-cloud-starter-stream-source-rabbit/README.adoc
@@ -46,6 +46,7 @@ $$rabbit.initial-retry-interval$$:: $$Initial retry interval when retry is enabl
 $$rabbit.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$[STANDARD_REQUEST_HEADERS]$$`)*
 $$rabbit.max-attempts$$:: $$The maximum delivery attempts when retry is enabled.$$ *($$Integer$$, default: `$$3$$`)*
 $$rabbit.max-retry-interval$$:: $$Max retry interval when retry is enabled.$$ *($$Integer$$, default: `$$30000$$`)*
+$$rabbit.own-connection$$:: $$When true, use a separate connection based on the boot properties.$$ *($$Boolean$$, default: `$$false$$`)*
 $$rabbit.queues$$:: $$The queues to which the source will listen for messages.$$ *($$String[]$$, default: `$$<none>$$`)*
 $$rabbit.requeue$$:: $$Whether rejected messages should be requeued.$$ *($$Boolean$$, default: `$$true$$`)*
 $$rabbit.retry-multiplier$$:: $$Retry backoff multiplier when retry is enabled.$$ *($$Double$$, default: `$$2$$`)*

--- a/spring-cloud-starter-stream-source-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceProperties.java
+++ b/spring-cloud-starter-stream-source-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/source/RabbitSourceProperties.java
@@ -76,6 +76,11 @@ public class RabbitSourceProperties {
 	 */
 	private boolean enableRetry = false;
 
+	/**
+	 * When true, use a separate connection based on the boot properties.
+	 */
+	private boolean ownConnection;
+
 	public boolean getRequeue() {
 		return requeue;
 	}
@@ -149,6 +154,14 @@ public class RabbitSourceProperties {
 
 	public void setEnableRetry(boolean enableRetry) {
 		this.enableRetry = enableRetry;
+	}
+
+	public boolean isOwnConnection() {
+		return this.ownConnection;
+	}
+
+	public void setOwnConnection(boolean ownConnection) {
+		this.ownConnection = ownConnection;
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-cloud-stream-app-starters/rabbit/issues/6

Add property `ownConnection`; when true the apps use a dedicated connection factory
configured from boot properties, regardless of whether the standard factory has been
replaced by PCF connectors.

Also fixes several deprecations.

**cherry-pick to master**