### PR TITLE
GH-26: Introduce PassThrouMessConverter for sink

### DIFF
--- a/spring-cloud-starter-stream-sink-rabbit/README.adoc
+++ b/spring-cloud-starter-stream-sink-rabbit/README.adoc
@@ -7,31 +7,11 @@ This module sends messages to RabbitMQ.
 
 === Headers
 
-* `content-type: text/plain`
-
-=== Payload
-
-* `String`
-
-=== Headers
-
-* `content-type: application/octet-stream`
+* propagated headers from the binder, including an original `contentType`
 
 === Payload
 
 * `byte[]`
-
-=== Headers
-
-* `content-type: application/x-java-serialized-object`
-
-=== Payload
-
-* `java.io.Serializable`
-
-Note: With `converterBeanName = jsonConverter` any object that can be converted to JSON by Jackson (content type sent to rabbit will be `application/json` with type information in other headers.
-
-With `converterBeanName` set to something else, payload will be any object that the converter can handle. 
 
 == Output
 
@@ -44,14 +24,11 @@ The **$$rabbit$$** $$sink$$ has the following options:
 (See the Spring Boot documentation for RabbitMQ connection properties)
 
 //tag::configuration-properties[]
-$$rabbit.converter-bean-name$$:: $$The bean name for a custom message converter; if omitted, a SimpleMessageConverter is used.
- If 'jsonConverter', a Jackson2JsonMessageConverter bean will be created for you.$$ *($$String$$, default: `$$<none>$$`)*
 $$rabbit.exchange$$:: $$Exchange name - overridden by exchangeNameExpression, if supplied.$$ *($$String$$, default: `$$<empty string>$$`)*
 $$rabbit.exchange-expression$$:: $$A SpEL expression that evaluates to an exchange name.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$rabbit.mapped-request-headers$$:: $$Headers that will be mapped.$$ *($$String[]$$, default: `$$[*]$$`)*
 $$rabbit.own-connection$$:: $$When true, use a separate connection based on the boot properties.$$ *($$Boolean$$, default: `$$false$$`)*
-$$rabbit.persistent-delivery-mode$$:: $$Default delivery mode when 'amqp_deliveryMode' header is not present,
- true for PERSISTENT.$$ *($$Boolean$$, default: `$$false$$`)*
+$$rabbit.persistent-delivery-mode$$:: $$Default delivery mode when 'amqp_deliveryMode' header is not present, true for PERSISTENT.$$ *($$Boolean$$, default: `$$false$$`)*
 $$rabbit.routing-key$$:: $$Routing key - overridden by routingKeyExpression, if supplied.$$ *($$String$$, default: `$$<none>$$`)*
 $$rabbit.routing-key-expression$$:: $$A SpEL expression that evaluates to a routing key.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$spring.rabbitmq.addresses$$:: $$Comma-separated list of addresses to which the client should connect.$$ *($$String$$, default: `$$<none>$$`)*
@@ -61,16 +38,10 @@ $$spring.rabbitmq.password$$:: $$Login to authenticate against the broker.$$ *($
 $$spring.rabbitmq.port$$:: $$RabbitMQ port.$$ *($$Integer$$, default: `$$5672$$`)*
 $$spring.rabbitmq.publisher-confirms$$:: $$Whether to enable publisher confirms.$$ *($$Boolean$$, default: `$$false$$`)*
 $$spring.rabbitmq.publisher-returns$$:: $$Whether to enable publisher returns.$$ *($$Boolean$$, default: `$$false$$`)*
-$$spring.rabbitmq.requested-heartbeat$$:: $$Requested heartbeat timeout; zero for none. If a duration suffix is not specified,
- seconds will be used.$$ *($$Duration$$, default: `$$<none>$$`)*
+$$spring.rabbitmq.requested-heartbeat$$:: $$Requested heartbeat timeout; zero for none. If a duration suffix is not specified, seconds will be used.$$ *($$Duration$$, default: `$$<none>$$`)*
 $$spring.rabbitmq.username$$:: $$Login user to authenticate to the broker.$$ *($$String$$, default: `$$guest$$`)*
 $$spring.rabbitmq.virtual-host$$:: $$Virtual host to use when connecting to the broker.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
-
-NOTE: By default, the message converter is a `SimpleMessageConverter` which handles `byte[]`, `String` and
-`java.io.Serializable`.
-A well-known bean name `jsonConverter` will configure a `Jackson2JsonMessageConverter` instead.
-In addition, a custom converter bean can be added to the context and referenced by the $$converterBeanName$$ property.
 
 == Build
 

--- a/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-rabbit/src/main/java/org/springframework/cloud/stream/app/rabbit/sink/RabbitSinkProperties.java
@@ -66,12 +66,6 @@ public class RabbitSinkProperties {
 	private String[] mappedRequestHeaders = { "*" };
 
 	/**
-	 * The bean name for a custom message converter; if omitted, a SimpleMessageConverter is used.
-	 * If 'jsonConverter', a Jackson2JsonMessageConverter bean will be created for you.
-	 */
-	private String converterBeanName;
-
-	/**
 	 * When true, use a separate connection based on the boot properties.
 	 */
 	private boolean ownConnection;
@@ -122,14 +116,6 @@ public class RabbitSinkProperties {
 
 	public void setMappedRequestHeaders(String[] mappedRequestHeaders) {
 		this.mappedRequestHeaders = mappedRequestHeaders;
-	}
-
-	public String getConverterBeanName() {
-		return this.converterBeanName;
-	}
-
-	public void setConverterBeanName(String converterBeanName) {
-		this.converterBeanName = converterBeanName;
 	}
 
 	@AssertTrue(message = "routingKey or routingKeyExpression is required")

--- a/spring-cloud-starter-stream-source-rabbit/README.adoc
+++ b/spring-cloud-starter-stream-source-rabbit/README.adoc
@@ -58,8 +58,7 @@ $$spring.rabbitmq.password$$:: $$Login to authenticate against the broker.$$ *($
 $$spring.rabbitmq.port$$:: $$RabbitMQ port.$$ *($$Integer$$, default: `$$5672$$`)*
 $$spring.rabbitmq.publisher-confirms$$:: $$Whether to enable publisher confirms.$$ *($$Boolean$$, default: `$$false$$`)*
 $$spring.rabbitmq.publisher-returns$$:: $$Whether to enable publisher returns.$$ *($$Boolean$$, default: `$$false$$`)*
-$$spring.rabbitmq.requested-heartbeat$$:: $$Requested heartbeat timeout; zero for none. If a duration suffix is not specified,
- seconds will be used.$$ *($$Duration$$, default: `$$<none>$$`)*
+$$spring.rabbitmq.requested-heartbeat$$:: $$Requested heartbeat timeout; zero for none. If a duration suffix is not specified, seconds will be used.$$ *($$Duration$$, default: `$$<none>$$`)*
 $$spring.rabbitmq.username$$:: $$Login user to authenticate to the broker.$$ *($$String$$, default: `$$guest$$`)*
 $$spring.rabbitmq.virtual-host$$:: $$Virtual host to use when connecting to the broker.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]


### PR DESCRIPTION
Fixes https://github.com/spring-cloud-stream-app-starters/rabbit/issues/26

Since binder always produces for us a message with the `byte[]` as a payload
and when we send to the RabbitMQ, we need a `byte[]` anyway, there is no
reason to try to convert an incoming `byte[]` to outbound one some how

* Introduce an internal `PassThroughMessageConverter` to always propagate
an incoming `byte[]` as is together with the `MessageProperties` provided
for us by the binder mapping, including an original `contentType`

* Refactor a `RabbitSinkConfiguration` for the proper inner classes structure
* Remove a `Jackson2JsonMessageConverter` bean definition since it is not
going to be used in  this app anyway
* Remove `converterBeanName` configuration property since it doesn't
bring any value any more
* Refactor `Input` section for the sink to reflect a reality of the
message produced by the binder before calling this Rabbit sink

**Cherry-pick to 2.0.x**